### PR TITLE
fix: sigstore/gh-action-sigstore-python version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
Looks like the action does not have the tag `v3`. fixed it.

See here: https://github.com/django-commons/drf-excel/actions/runs/11465977687/job/31905724008