### PR TITLE
Add support for Django 5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
-    dj52: Django>=5.2a1,<6.0
+    dj52: Django>=5.2b1,<6.0
 
     djangorestframework
     openpyxl

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{39,310,311}-dj42
     py{310,311,312}-dj50
     py{310,311,312,313}-dj51
+    py{310,311,312,313}-dj52
 skipsdist = True
 
 [testenv]
@@ -10,6 +11,7 @@ deps =
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2a1,<6.0
 
     djangorestframework
     openpyxl


### PR DESCRIPTION
Django 5.2 is due to be released in a few weeks: https://thib.me/django-packages-already-on-5-2

- [x] Update tox config to run tests against 5.2
- [x] Update Trove classifiers to declare support for 5.2