### PR TITLE
Do not instantiate serializer when unnecessary

### DIFF
--- a/drf_excel/renderers.py
+++ b/drf_excel/renderers.py
@@ -156,10 +156,16 @@ class XLSXRenderer(BaseRenderer):
             # 'custom_func', allowing for formatting logic
             self.custom_mappings = getattr(drf_view, "xlsx_custom_mappings", dict())
 
-            self.fields_dict = self._serializer_fields(drf_view.get_serializer())
+            try:
+                serializer = data.serializer
+            except AttributeError:
+                serializer = drf_view.get_serializer()
+            serializer = getattr(serializer, "child", serializer)
+
+            self.fields_dict = self._serializer_fields(serializer)
 
             xlsx_header_dict = self._flatten_serializer_keys(
-                drf_view.get_serializer(), use_labels=use_labels
+                serializer, use_labels=use_labels
             )
             if self.custom_cols:
                 custom_header_dict = {

--- a/tests/test_viewset_mixin.py
+++ b/tests/test_viewset_mixin.py
@@ -112,8 +112,24 @@ def test_secret_field_viewset(api_client, workbook_reader):
     assert [col.value for col in data] == ["foo"]
 
 
-def test_dynamic_field_viewset(api_client, workbook_reader):
+def test_list_dynamic_field_viewset(api_client, workbook_reader):
     response = api_client.get("/dynamic-field/")
+    assert response.status_code == 200
+
+    wb = workbook_reader(response.content)
+    sheet = wb.worksheets[0]
+
+    header, data = list(sheet.rows)
+
+    header_values = [cell.value for cell in header]
+    assert header_values == ["field_1", "field_98"]
+
+    row_1_values = [cell.value for cell in data]
+    assert row_1_values == ["YUL", "MAR"]
+
+
+def test_detail_dynamic_field_viewset(api_client, workbook_reader):
+    response = api_client.get("/dynamic-field/0/")
     assert response.status_code == 200
 
     wb = workbook_reader(response.content)
@@ -139,3 +155,19 @@ def test_auto_filter_viewset(api_client, workbook_reader):
     sheet = wb.worksheets[0]
 
     assert sheet.auto_filter.ref == "A1:B2"
+
+
+def test_plain_response_view(api_client, workbook_reader):
+    response = api_client.get("/plain/", {"format": "xlsx"})
+    assert response.status_code == 200
+
+    wb = workbook_reader(response.content)
+    sheet = wb.worksheets[0]
+
+    header, data = sheet.rows
+
+    header_values = [cell.value for cell in header]
+    assert header_values == ["title", "description"]
+
+    row_1_values = [cell.value for cell in data]
+    assert row_1_values == ["Test Title", "Test Description"]

--- a/tests/testapp/serializers.py
+++ b/tests/testapp/serializers.py
@@ -45,3 +45,12 @@ class DynamicFieldSerializer(serializers.Serializer):
         # Fields can be added dynamically
         self.fields["field_99"] = serializers.CharField()
         self.fields["field_98"] = serializers.CharField()
+
+    @classmethod
+    def many_init(cls, *args, **kwargs):
+        list_serializer = super().many_init(*args, **kwargs)
+
+        # Some fields may be deleted from the list serializer.
+        del list_serializer.child.fields["field_2"]
+        del list_serializer.child.fields["field_99"]
+        return list_serializer

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -1,5 +1,7 @@
+from django.http import Http404
+from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from drf_excel.mixins import XLSXFileMixin
 from drf_excel.renderers import XLSXRenderer
@@ -34,23 +36,25 @@ class SecretFieldViewSet(XLSXFileMixin, ReadOnlyModelViewSet):
     filename = "secret.xlsx"
 
 
-class DynamicFieldViewSet(XLSXFileMixin, GenericViewSet):
+class DynamicFieldViewSet(XLSXFileMixin, ReadOnlyModelViewSet):
     serializer_class = DynamicFieldSerializer
     renderer_classes = (XLSXRenderer,)
     filename = "dynamic_field.xlsx"
+    queryset = [{
+        "field_1": "YUL",
+        "field_2": "CDG",
+        "field_55": "LHR",
+        "field_98": "MAR",
+        "field_99": "YYZ",
+    }]
 
-    def list(self, request, *args, **kwargs):
-        serializer = self.get_serializer(
-            data={
-                "field_1": "YUL",
-                "field_2": "CDG",
-                "field_55": "LHR",
-                "field_98": "MAR",
-                "field_99": "YYZ",
-            }
-        )
-        serializer.is_valid(raise_exception=True)
-        return Response(serializer.data)
+    def get_object(self):
+        """Get object by index from the list assigned to queryset."""
+
+        try:
+            return self.queryset[int(self.kwargs["pk"])]
+        except (KeyError, ValueError):
+            raise Http404
 
 
 class AutoFilterViewSet(XLSXFileMixin, ReadOnlyModelViewSet):
@@ -59,3 +63,12 @@ class AutoFilterViewSet(XLSXFileMixin, ReadOnlyModelViewSet):
     renderer_classes = (XLSXRenderer,)
 
     xlsx_auto_filter = True
+
+
+class PlainResponseView(GenericAPIView):
+    serializer_class = ExampleSerializer
+
+    def get(self, request):
+        """Get response with built-in dict not from serializer data."""
+
+        return Response({"title": "Test Title", "description": "Test Description"})

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,3 +1,4 @@
+from django.urls import path
 from rest_framework import routers
 
 from .testapp.views import (
@@ -5,6 +6,7 @@ from .testapp.views import (
     AutoFilterViewSet,
     DynamicFieldViewSet,
     ExampleViewSet,
+    PlainResponseView,
     SecretFieldViewSet,
 )
 
@@ -15,4 +17,6 @@ router.register(r"secret-field", SecretFieldViewSet)
 router.register(r"dynamic-field", DynamicFieldViewSet, basename="dynamic-field")
 router.register(r"auto-filter", AutoFilterViewSet, basename="auto-filter")
 
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path("plain/", PlainResponseView.as_view()),
+]


### PR DESCRIPTION
Instead, inspect serializer fields from the provided ReturnDict as data.

A view may use a serializer with dynamic fields which vary depending on arguments. For instance, a list serializer may have fewer fields than a detail serializer, and that difference may depend on `many=True` flag.

DRF provides a reference to the serializer in an attribute on data if data is instance of ReturnDict. If it is available, we can rely on actual serializer. Otherwise, the patch persists the previous logic under AttributeError handling. I have added a test for this case.

https://github.com/encode/django-rest-framework/blob/65aa4b8608e3fd5f32d1d077504e8671991ebe28/rest_framework/serializers.py#L586