### PR TITLE
Pin pytest-django to fix CI failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     Pillow
 
     pytest
-    pytest-django
+    pytest-django<4.13.0
     pytest-cov
     django-coverage-plugin
     time-machine


### PR DESCRIPTION
pytest-django v4.13.0 was released yesterday and dropped support for unmaintained Django versions:
https://pytest-django.readthedocs.io/en/latest/changelog.html#v4-13-0-2026-08-06

Pin it until we drop support too