### PR TITLE
Fix package metadata causing warnings raised during 'uv build'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,11 @@ dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["djangorestframework", "django rest framework", "excel", "spreadsheet", "rest", "restful", "api", "xls", "xlsx", "openpyxl"]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -48,7 +47,7 @@ dev = [
 "Documentation" = "https://github.com/django-commons/drf-excel/"
 
 [build-system]
-requires = ["setuptools>=67", "setuptools_scm>=7", "wheel"]
+requires = ["setuptools>=77", "setuptools_scm>=7"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
They cause [some warnings during 'uv build'](https://github.com/django-commons/drf-excel/actions/runs/31093653729/job/92590340859#step:5:15), and I suspect that might be why [the release failed](https://github.com/django-commons/drf-excel/actions/runs/31093653729)...