### PR TITLE
Run tox against stable DRF again

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,7 @@ deps =
     dj60: Django>=6.0,<6.1
     dj61: Django>=6.1,<6.2
 
-    # Django 6.1 support is only on DRF's main branch so far
-    !dj61: djangorestframework
-    dj61: djangorestframework @ https://github.com/encode/django-rest-framework/archive/main.zip
-
+    djangorestframework
     openpyxl
     Pillow
 


### PR DESCRIPTION
Now that DRF 3.18 is out