### PR TITLE
Exported data with a "detail" field gets sent back as raw JSON instead of an XLSX file

### DIFF
--- a/drf_excel/renderers.py
+++ b/drf_excel/renderers.py
@@ -59,7 +59,7 @@ class XLSXRenderer(BaseRenderer):
         if data is None:
             return b""
 
-        if not self._check_validation_data(data):
+        if not self._check_validation_data(data, renderer_context):
             return json.dumps(data)
 
         wb = Workbook()
@@ -244,7 +244,12 @@ class XLSXRenderer(BaseRenderer):
 
         return virtual_workbook
 
-    def _check_validation_data(self, data):
+    def _check_validation_data(self, data, renderer_context=None):
+        response = (renderer_context or {}).get("response")
+        if response is not None:
+            return 200 <= response.status_code < 300
+        # No response available (e.g. calling the renderer directly) -
+        # fall back to the old heuristic.
         detail_key = "detail"
         return detail_key not in data
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -24,6 +24,31 @@ class TestXLSXRenderer:
     def test_validation_error(self):
         assert self.renderer.render({"detail": "invalid"}) == '{"detail": "invalid"}'
 
+    def test_validation_with_successful_response(self):
+        """
+        A successful (200) response whose payload happens to contain a
+        "detail" key - a perfectly ordinary field name for real data -
+        should still be treated as valid data, not short-circuited to raw
+        JSON.
+
+        https://github.com/django-commons/drf-excel/issues/26
+        """
+        data = {"detail": "Successfully processed 3 records", "count": 3}
+        response = Response(data, status=200)
+        response.renderer_context = {"response": response}
+        assert self.renderer._check_validation_data(data, response.renderer_context)
+
+    def test_validation_with_custom_error_response(self):
+        """
+        A real error response from a custom exception handler that
+        doesn't use Django REST Framework's "detail" convention should
+        still be treated as an error, based on the response status code.
+        """
+        data = {"error_code": "RATE_LIMITED", "message": "Too many requests"}
+        response = Response(data, status=429)
+        response.renderer_context = {"response": response}
+        assert not self.renderer._check_validation_data(data, response.renderer_context)
+
     def test_none(self):
         assert self.renderer.render(None) == b""
 


### PR DESCRIPTION
Closes #26

One of my endpoints returns a payload that legitimately includes a `detail` field (a status message alongside the actual data) as part of a normal, successful response. Exporting it through drf-excel didn't produce a spreadsheet at all - I got the raw JSON dumped back instead, with no error, no explanation.

The cause: `_check_validation_data()` decides whether to treat a response as an error purely by checking whether `"detail"` is a key in the payload - `detail_key not in data`. That's a coincidental convention DRF's *default* error responses happen to use, not a reliable signal - any real payload with a field named `detail`, or a custom exception handler that shapes errors differently, gets this wrong in both directions.

This PR switches the check to use the actual response status code instead, which `renderer_context` already carries (DRF always sets `renderer_context["response"]` to the real `Response` object before calling a renderer). A 2xx status is valid data and gets rendered as XLSX regardless of what keys the payload happens to have; anything else is treated as an error and passed through as JSON, even if the error body doesn't use a `detail` key at all. Falls back to the old `detail`-key heuristic only when no response is available (e.g. calling the renderer directly, which the existing test suite already does in one place).

Reproduced both directions before writing the fix: a successful 200 response with a payload containing `detail` (confirmed it was being wrongly treated as an error and dumped as JSON), and a custom-shaped 429 error response with no `detail` key at all (confirmed the *old* code would have wrongly treated it as valid data). Added regression tests for both; full suite (146 tests) green with 100% coverage on `drf_excel/renderers.py`, ruff clean.